### PR TITLE
Use socket.SO_REUSEADDR before binding

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,3 +11,8 @@ History
 ------------------
 
 * Beta release on PyPI.
+
+0.4.1 (2017-05-13)
+------------------
+
+* Fix "[Errno 98] Address already in use" error when restarting the daemon

--- a/onionrouter/__init__.py
+++ b/onionrouter/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Ehlo Onion"""
 __email__ = 'onionmx@lists.immerda.ch'
-__version__ = '0.4.0'
+__version__ = '0.4.1'

--- a/onionrouter/msockets.py
+++ b/onionrouter/msockets.py
@@ -32,6 +32,7 @@ def resolve(rerouter, conn, resolve_callback=lambda q, a: (q, a)):
 
 def daemonize_server(rerouter, host, port, resolver=resolve):
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     sock.bind((host, port))
     sock.listen(1)
     atexit.register(close_socket, sock=sock)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.4.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ test_requirements = [
 
 setup(
     name='onionrouter',
-    version='0.4.0',
+    version='0.4.1',
     description="Python Onion Routed Mail Deliveries",
     long_description=readme + '\n\n' + history,
     author="Ehlo Onion",


### PR DESCRIPTION
 * Fixes "[Errno 98] Address already in use" error when restarting the
daemon
 * Bump version to 0.4.1