### PR TITLE
Ignored domains support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,14 +82,15 @@ Configuration and other options
 -------------------------------
 * Copy or update the onionrouter.ini file and with your settings (reference file is in onionrouter/configs folder if you cloned the git repo or in /etc/onionrouter/ if you installed the package)
 * Edit the configuration file
-    * Under the DOMAIN section replace the value of the **hostname** key with your local domain to be whitelisted from lookups. To add multiple local domains, separate them with comma ','
-    * Under the RESOLVER section put in the **resolver_ip** field your preferred resolver (default is 127.0.0.1). To use multiple resolvers, separate them with comma ','
-    * Under the RESOLVER section put in the **resolver_port** field the port that your resolver listens to (default is 53)
+    * Under the **DOMAIN** section replace the value of the **hostname** key with your local domain to be whitelisted from lookups. To add multiple local domains, separate them with comma ','
+    * Under the **RESOLVER** section put in the **resolver_ip** field your preferred resolver (default is 127.0.0.1). To use multiple resolvers, separate them with comma ','
+    * Under the **RESOLVER** section put in the **resolver_port** field the port that your resolver listens to (default is 53)
 
 onionrouter by default queries the destination domain for a specific SRV record, *_onion-mx._tcp.* and if it finds a .onion address in the reply it gives it back to postfix to be used by the smtptor service defined in master.cf. If no valid SRV record is found the mail is passed to smtp service. This gives us dynamic SRV lookups that lead to SMTP over onion addresses!
 
-* To change the SRV record the scripts looks for, edit the config file mentioned above and change under the DNS section the srv_record field with the SRV record you have setup (default is _onion-mx._tcp.)
-* To change the service that will be used when a .onion address is found, edit the config file mentioned above and change under the REROUTE section the onion_transport field with the service you want to be used (default is smtptor)
+* To change the SRV record the scripts looks for, edit the config file mentioned above and change under the **DNS** section the **srv_record** field with the SRV record you have setup (default is _onion-mx._tcp.)
+* To change the service that will be used when a .onion address is found, edit the config file mentioned above and change under the **REROUTE** section the **onion_transport** field with the service you want to be used (default is smtptor)
+* To *blacklist/ignore* domains in case you have a custom routing rule, or a black list of domains, add those domains under the **IGNORED** section in the **domains** field. For multiple domains, separate them with comma ','.
 
 Execution options
 -----------------

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,43 @@
+from __future__ import unicode_literals
+import pytest
+import io
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
+from onionrouter import onionrouter, config_handlers
+
+
+config = """
+[RESOLVER]
+resolver_ip: 127.0.0.1
+resolver_port: 53
+tcp: True
+
+[DOMAIN]
+hostname: myself.net, myself2.net
+
+[DNS]
+srv_record: _onion-mx._tcp.
+
+[REROUTE]
+onion_transport: smtptor
+"""
+
+
+@pytest.fixture(scope="session", name="dummy_config")
+def fixture_config():
+    return config
+
+
+@pytest.fixture(scope="function", name="dummy_onionrouter")
+def fixture_onionrouter(monkeypatch, dummy_config):
+    monkeypatch.setattr(
+        config_handlers, "get_conffile",
+        lambda *args, **kwargs: onionrouter.OnionRouter.ref_config)
+    custom_config = configparser.ConfigParser()
+    custom_config._read(io.StringIO(dummy_config), None)
+    monkeypatch.setattr(config_handlers, "config_reader",
+                        lambda *args: custom_config)
+    return onionrouter.OnionRouter("nothing?")
+

--- a/conftest.py
+++ b/conftest.py
@@ -5,7 +5,7 @@ try:
     import configparser
 except ImportError:
     import ConfigParser as configparser
-from onionrouter import onionrouter, config_handlers
+from onionrouter import rerouter, config_handlers
 
 
 config = """
@@ -37,10 +37,10 @@ def fixture_config():
 def fixture_onionrouter(monkeypatch, dummy_config):
     monkeypatch.setattr(
         config_handlers, "get_conffile",
-        lambda *args, **kwargs: onionrouter.OnionRouter.ref_config)
+        lambda *args, **kwargs: rerouter.OnionRouter.ref_config)
     custom_config = configparser.ConfigParser()
     custom_config._read(io.StringIO(dummy_config), None)
     monkeypatch.setattr(config_handlers, "config_reader",
                         lambda *args: custom_config)
-    return onionrouter.OnionRouter("nothing?")
+    return rerouter.OnionRouter("nothing?")
 

--- a/conftest.py
+++ b/conftest.py
@@ -22,6 +22,9 @@ srv_record: _onion-mx._tcp.
 
 [REROUTE]
 onion_transport: smtptor
+
+[IGNORED]
+domains: ignore.me, ignore2.me
 """
 
 

--- a/onionrouter/__init__.py
+++ b/onionrouter/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Ehlo Onion"""
 __email__ = 'onionmx@lists.immerda.ch'
-__version__ = '0.4.1'
+__version__ = '0.5.0'

--- a/onionrouter/config_handlers.py
+++ b/onionrouter/config_handlers.py
@@ -4,8 +4,9 @@ try:
 except ImportError:
     import configparser
 from yaml import load
-from .olib import find_file, find_files_with_suffix
-from .custom_exceptions import ConfigIntegrityError, ConfigNotFoundError
+from onionrouter.olib import find_file, find_files_with_suffix
+from onionrouter.custom_exceptions import (ConfigIntegrityError,
+                                           ConfigNotFoundError)
 
 
 class ConfigIntegrityChecker(object):

--- a/onionrouter/configs/onionrouter.ini
+++ b/onionrouter/configs/onionrouter.ini
@@ -11,3 +11,6 @@ srv_record:          _onion-mx._tcp.
 
 [REROUTE]
 onion_transport:     smtptor
+
+[IGNORED]
+domains:             ignored.com

--- a/onionrouter/msockets.py
+++ b/onionrouter/msockets.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 import socket
 import multiprocessing
 import atexit
-from . import olib
+from onionrouter import olib
 
 
 def close_socket(sock):

--- a/onionrouter/onionrouter.py
+++ b/onionrouter/onionrouter.py
@@ -40,7 +40,10 @@ class OnionRouter(object):
 
     @staticmethod
     def get_domain(name):
-        return name.split("@")[1]
+        split_name = name.split("@")
+        if name.count("@") != 1 or split_name[1] == "":
+            raise RuntimeError
+        return split_name[1]
 
     def reroute(self, domain):
         if domain.upper() in self.myname:
@@ -52,7 +55,7 @@ class OnionRouter(object):
     def run(self, address):
         try:
             domain = self.get_domain(address)
-        except IndexError:
+        except RuntimeError:
             return "500 Request key is not an email address"
         routing = self.reroute(domain)
         # in the end, there can be only one response

--- a/onionrouter/onionrouter.py
+++ b/onionrouter/onionrouter.py
@@ -38,16 +38,23 @@ class OnionRouter(object):
         return [x.strip().upper() for x in self.config.get(
             "DOMAIN", "hostname").split(",")]
 
+    @property
+    def ignored_domains(self):
+        return [x.strip().upper() for x in self.config.get(
+            "IGNORED", "domains").split(",")]
+
     @staticmethod
-    def get_domain(name):
-        split_name = name.split("@")
-        if name.count("@") != 1 or split_name[1] == "":
+    def get_domain(address):
+        split_addr = address.split("@")
+        if address.count("@") != 1 or split_addr[1] == "":
             raise RuntimeError
-        return split_name[1]
+        return split_addr[1]
 
     def reroute(self, domain):
         if domain.upper() in self.myname:
             return tuple(["200 :"])
+        elif domain.upper() in self.ignored_domains:
+            return tuple(["500 Domain is in ignore list"])
         else:
             return (self.rerouters.lazy.reroute(domain)
                     or self.rerouters.onion.reroute(domain))

--- a/onionrouter/onionrouter.py
+++ b/onionrouter/onionrouter.py
@@ -21,7 +21,7 @@ class OnionRouter(object):
                                        "configs/onionrouter.ini"))
     rerouters = namedtuple('rerouters', ('lazy', 'onion'))
 
-    def __init__(self, config_path, map_path=None):
+    def __init__(self, config_path, map_path=""):
         self.config_file = config_handlers.get_conffile(config_path,
                                                         prefix="onionrouter")
         self.mappings_path = map_path

--- a/onionrouter/rerouter.py
+++ b/onionrouter/rerouter.py
@@ -6,9 +6,9 @@ from functools import partial
 from pkg_resources import resource_filename
 import sys
 from socket import error as socket_error
-from .lookups import OnionServiceLookup
-from . import (config_handlers, custom_exceptions as exc,
-               msockets, olib, routers)
+from onionrouter.lookups import OnionServiceLookup
+from onionrouter import (config_handlers, custom_exceptions as exc,
+                         msockets, olib, routers)
 
 
 default_config_path = "/etc/onionrouter/"

--- a/onionrouter/routers.py
+++ b/onionrouter/routers.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod, ABCMeta
 from dns import exception as dnsexception
-from .config_handlers import load_yamls
+from onionrouter.config_handlers import load_yamls
 
 
 class PostfixRerouter(object):

--- a/onionrouter_run
+++ b/onionrouter_run
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Convenience wrapper for running onionrouter directly from source tree."""
-from onionrouter.onionrouter import main
+from onionrouter.rerouter import main
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-dnspython
-PyYAML
+dnspython==1.15.0
+PyYAML==3.11

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,5 +7,4 @@ tox==2.3.1
 coverage==4.1
 Sphinx==1.5.3
 cryptography==1.7
-PyYAML==3.11
-pytest==2.9.2
+pytest==3.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.1
+current_version = 0.5.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ test_requirements = [
 
 setup(
     name='onionrouter',
-    version='0.4.1',
+    version='0.5.0',
     description="Python Onion Routed Mail Deliveries",
     long_description=readme + '\n\n' + history,
     author="Ehlo Onion",

--- a/tests/test_onionrouter.py
+++ b/tests/test_onionrouter.py
@@ -18,12 +18,16 @@ class TestOnionRouter(object):
     def test_hostname_is_upper(self, dummy_onionrouter):
         assert all(x.isupper() for x in dummy_onionrouter.myname) is True
 
-@pytest.fixture
-def response():
-    """Sample pytest fixture.
-    See more at: http://doc.pytest.org/en/latest/fixture.html
-    """
-    # import requests
-    # return requests.get('https://github.com/audreyr/cookiecutter-pypackage')
+    def test_get_domain_multiple_at(self, dummy_onionrouter):
+        with pytest.raises(RuntimeError):
+            dummy_onionrouter.get_domain("lalla@lalala.com@lalal.net")
 
+    def test_get_domain_no_email(self, dummy_onionrouter):
+        with pytest.raises(RuntimeError):
+            dummy_onionrouter.get_domain("lalla")
 
+    def test_get_domain_correct_email(self, dummy_onionrouter):
+        assert dummy_onionrouter.get_domain("lol@test.com") == "test.com"
+
+    def test_reroute_local_domain(self, dummy_onionrouter):
+        assert dummy_onionrouter.reroute("myself.net") == tuple(["200 :"])

--- a/tests/test_onionrouter.py
+++ b/tests/test_onionrouter.py
@@ -17,7 +17,7 @@ class TestOnionRouter(object):
         assert len(dummy_onionrouter.myname) > 1
 
     def test_hostname_is_upper(self, dummy_onionrouter):
-        assert all(x.isupper() for x in dummy_onionrouter.myname) is True
+        assert all(map(lambda x: x.isupper(), dummy_onionrouter.myname))
 
     def test_get_domain_multiple_at(self, dummy_onionrouter):
         with pytest.raises(RuntimeError):
@@ -50,3 +50,17 @@ class TestOnionRouter(object):
         monkeypatch.setattr(OnionPostfixRerouter, "reroute",
                             lambda *args: dummy_answer)
         assert dummy_onionrouter.run("t@t.c") == dummy_answer[0]
+
+    def test_ignored_domains_exist(self, dummy_onionrouter):
+        assert dummy_onionrouter.ignored_domains
+
+    def test_ignored_domains_case_insensitive(self, dummy_onionrouter):
+        assert all(map(lambda x: x.isupper(),
+                       dummy_onionrouter.ignored_domains))
+
+    def test_ignored_domain_rerouting(self, dummy_onionrouter):
+        assert (dummy_onionrouter.run("please@iGnORe.Me")
+                == "500 Domain is in ignore list")
+
+    def test_check_local_domain_before_ignored(self, dummy_onionrouter):
+        assert dummy_onionrouter.run("m@myself.net") == "200 :"

--- a/tests/test_onionrouter.py
+++ b/tests/test_onionrouter.py
@@ -39,3 +39,14 @@ class TestOnionRouter(object):
         monkeypatch.setattr(OnionPostfixRerouter, "reroute",
                             lambda *args: dummy_answer)
         assert dummy_onionrouter.reroute("testme") == dummy_answer
+
+    def test_reroute_run_wrong_domain(self, dummy_onionrouter):
+        assert (dummy_onionrouter.run("llalalla")
+                == "500 Request key is not an email address")
+
+    def test_reroute_multiple_findings(self, dummy_onionrouter,
+                                       monkeypatch):
+        dummy_answer = tuple(["test1", "test2", "test3"])
+        monkeypatch.setattr(OnionPostfixRerouter, "reroute",
+                            lambda *args: dummy_answer)
+        assert dummy_onionrouter.run("t@t.c") == dummy_answer[0]

--- a/tests/test_onionrouter.py
+++ b/tests/test_onionrouter.py
@@ -9,6 +9,7 @@ Tests for `onionrouter` module.
 """
 
 import pytest
+from onionrouter.routers import OnionPostfixRerouter
 
 
 class TestOnionRouter(object):
@@ -31,3 +32,10 @@ class TestOnionRouter(object):
 
     def test_reroute_local_domain(self, dummy_onionrouter):
         assert dummy_onionrouter.reroute("myself.net") == tuple(["200 :"])
+
+    def test_reroute_no_lazy_config(self, dummy_onionrouter,
+                                    monkeypatch):
+        dummy_answer = tuple(["test"])
+        monkeypatch.setattr(OnionPostfixRerouter, "reroute",
+                            lambda *args: dummy_answer)
+        assert dummy_onionrouter.reroute("testme") == dummy_answer

--- a/tests/test_onionrouter.py
+++ b/tests/test_onionrouter.py
@@ -11,8 +11,12 @@ Tests for `onionrouter` module.
 import pytest
 
 
-from onionrouter import onionrouter
+class TestOnionRouter(object):
+    def test_multiple_hostnames_support(self, dummy_onionrouter):
+        assert len(dummy_onionrouter.myname) > 1
 
+    def test_hostname_is_upper(self, dummy_onionrouter):
+        assert all(x.isupper() for x in dummy_onionrouter.myname) is True
 
 @pytest.fixture
 def response():
@@ -23,8 +27,3 @@ def response():
     # return requests.get('https://github.com/audreyr/cookiecutter-pypackage')
 
 
-def test_content(response):
-    """Sample pytest test function with the pytest fixture as an argument.
-    """
-    # from bs4 import BeautifulSoup
-    # assert 'GitHub' in BeautifulSoup(response.content).title.string

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ commands=flake8 onionrouter
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/onionrouter
 deps =
+    -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements_dev.txt
 commands =
     pip install -U pip


### PR DESCRIPTION
- Adds support for (multiple) domains that must be ignored. Returns 500 response for these
- Adds tests for `onionrouter` module and solves some minor bugs
- Renames `onionrouter` module to `rerouter` for absolute imports
- Fixes #10 