### PR TITLE
Include conftest.py in the source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,8 @@ include HISTORY.rst
 include LICENSE
 include README.rst
 
+include conftest.py
+
 recursive-include onionrouter *.ini
 recursive-include tests *
 recursive-exclude * __pycache__


### PR DESCRIPTION
Without conftest.py, pytest fails to run tests because it cannot find the `dummy_onionrouter` fixture:

```
_____________________________________________________________________________________ ERROR at setup of TestOnionRouter.test_multiple_hostnames_support ______________________________________________________________________________________
file tests/test_onionrouter.py, line 16
      def test_multiple_hostnames_support(self, dummy_onionrouter):
E       fixture 'dummy_onionrouter' not found
>       available fixtures: cache, capfd, capfdbinary, caplog, capsys, capsysbinary, doctest_namespace, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.
```