### PR TITLE
Allow for use of later versions of PyYAML

### DIFF
--- a/onionrouter/msockets.py
+++ b/onionrouter/msockets.py
@@ -18,7 +18,8 @@ def resolve(rerouter, conn, resolve_callback=lambda q, a: (q, a)):
                 # connection ended
                 return
             if addr == 'get *':
-                conn.sendall("500 Request key is not an email address\n".encode())
+                conn.sendall("500 Request key is not an email address\n"
+                        .encode())
             else:
                 result = rerouter.run(addr)
                 resolve_callback(addr, result)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = [
-    "dnspython<=2.0.0",
+    "dnspython>=2.0.0,<3.0.0",
     "PyYAML>=4.2b1,<6.0.0",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [
     "dnspython<=2.0.0",
-    "PyYAML==4.2b1",
+    "PyYAML>=4.2b1,<6.0.0",
 ]
 
 test_requirements = [


### PR DESCRIPTION
commit 5fe349a "Update PyYAML to 4.2b1 due to CVE-2017-18342" set `install_requires` to `PyYAML==4.2b1`. This exact version requirement prohibits the use of later versions of PyYAML.