### PR TITLE
Send a newline when replying to postfix

### DIFF
--- a/onionrouter/msockets.py
+++ b/onionrouter/msockets.py
@@ -27,7 +27,7 @@ def resolve(rerouter, conn, resolve_callback=lambda q, a: (q, a)):
         return
     except BaseException as err:
         # todo log
-        conn.sendall("500 {0}".format(err))
+        conn.sendall("500 {0}\n".format(err))
 
 
 def daemonize_server(rerouter, host, port, resolver=resolve):


### PR DESCRIPTION
Postfix requires all replies to end in a newline.

Without this change, postfix logs a warning:
`warning: read TCP map reply from localhost:23000: text longer than 4096`

See http://www.postfix.org/tcp_table.5.html