### PR TITLE
Allow pyyaml 6.0; Bump pyyaml from 5.4 to 6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ test_requirements = [
     "coverage==4.1",
     "Sphinx==1.4.8",
     "cryptography==3.3.2",
-    "PyYAML==5.4",
+    "PyYAML==6.0",
     "pytest==2.9.2"
 ]
 


### PR DESCRIPTION
Remove the `PyYAML<6.0.0` restriction and bump PyYAML to 6.0 for testing.

Bumps [pyyaml](https://github.com/yaml/pyyaml) from 5.4 to 6.0.
- [Release notes](https://github.com/yaml/pyyaml/releases)
- [Changelog](https://github.com/yaml/pyyaml/blob/master/CHANGES)
- [Commits](https://github.com/yaml/pyyaml/compare/5.4...6.0)
