### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,5 @@ python:
   - 3.7
   - 3.8
   - 3.9
+  - 3.10-dev
 script: tox -e ${TOXENV}

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
     test_suite='tests',
     tests_require=test_requirements


### PR DESCRIPTION
Python 3.10 is out: https://www.python.org/downloads/release/python-3100/

Mind as well indicate support for it and configure Travis to test against it.